### PR TITLE
Add Git LFS Pull Step

### DIFF
--- a/src/commands/shallow-checkout.yml
+++ b/src/commands/shallow-checkout.yml
@@ -164,3 +164,9 @@ steps:
         then
           git submodule update --init --recursive
         fi
+
+        # explicilty pull LFS if needed
+        if [ "<< parameters.fetch_lfs >>" == "true" ]
+        then
+          git lfs pull
+        fi


### PR DESCRIPTION
We need to determine if this is needed, I believe _not_, because we are assuming that Git LFS is setup ahead of this operation and the initial clone step should handle this for us (if LFS fetch isn't disabled).

That being said, this might be worthwhile to try for debugging.

I would not merge this until we validate it's necessary.